### PR TITLE
feat: add demo offline mode

### DIFF
--- a/mobile-frontend/app/AppWithNotifications.tsx
+++ b/mobile-frontend/app/AppWithNotifications.tsx
@@ -14,6 +14,7 @@ import { FontSizeProvider } from '@/contexts/FontSizeContext';
 import { Platform, Alert, Linking } from 'react-native';
 import { I18nContext } from '@/contexts/i18n-context';
 import { useUpdateAlerts } from '@/hooks/useUpdateAlerts';
+import DemoBanner from '@/components/DemoBanner';
 
 // Helper function to guide users for battery optimization
 const showBatteryOptimizationAlert = async (i18n: any, language: string) => {
@@ -199,6 +200,7 @@ const AppWithNotifications: React.FC = () => {
         <SessionDependentPushTokenHandler pushToken={pushToken} />
         <StudentProvider>
           <FontSizeProvider>
+            <DemoBanner />
             <Slot />
           </FontSizeProvider>
         </StudentProvider>

--- a/mobile-frontend/components/DemoBanner.tsx
+++ b/mobile-frontend/components/DemoBanner.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useSession } from '@/contexts/auth-context';
+
+const DemoBanner: React.FC = () => {
+  const { isDemo } = useSession();
+  if (!isDemo) return null;
+  return (
+    <View style={styles.banner}>
+      <ThemedText style={styles.text}>
+        {"Demo data – changes won't sync."}
+      </ThemedText>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  banner: {
+    backgroundColor: '#FDE68A',
+    paddingVertical: 4,
+    alignItems: 'center',
+  },
+  text: {
+    color: '#92400E',
+    fontSize: 12,
+  },
+});
+
+export default DemoBanner;

--- a/mobile-frontend/constants/demoData.ts
+++ b/mobile-frontend/constants/demoData.ts
@@ -1,0 +1,69 @@
+import { Student, Message } from './types';
+
+const now = new Date().toISOString();
+
+export const demoStudents: Student[] = [
+  {
+    id: 1,
+    family_name: 'Demo',
+    given_name: 'Student',
+    student_number: 'S001',
+    email: 'student1@example.com',
+    phone_number: '+199955501',
+    messageCount: 0,
+    unread_count: 0,
+  },
+  {
+    id: 2,
+    family_name: 'Sample',
+    given_name: 'Learner',
+    student_number: 'S002',
+    email: 'student2@example.com',
+    phone_number: '+199955502',
+    messageCount: 0,
+    unread_count: 0,
+  },
+];
+
+export const demoMessages: {
+  student_id: number;
+  student_number: string;
+  messages: Message[];
+}[] = [
+  {
+    student_id: 1,
+    student_number: 'S001',
+    messages: [
+      {
+        id: 1001,
+        title: 'Welcome',
+        content: 'Welcome to the demo mode.',
+        priority: 'low',
+        group_name: null,
+        edited_at: now,
+        images: null,
+        sent_time: now,
+        viewed_at: null,
+        read_status: 0,
+      },
+    ],
+  },
+  {
+    student_id: 2,
+    student_number: 'S002',
+    messages: [
+      {
+        id: 2001,
+        title: 'Greetings',
+        content: 'This is an example message.',
+        priority: 'low',
+        group_name: null,
+        edited_at: now,
+        images: null,
+        sent_time: now,
+        viewed_at: null,
+        read_status: 0,
+      },
+    ],
+  },
+];

--- a/mobile-frontend/utils/queries.ts
+++ b/mobile-frontend/utils/queries.ts
@@ -105,6 +105,29 @@ export const fetchStudentsFromDB = async (
   }));
 };
 
+export const saveStudentsToDB = async (
+  database: SQLiteDatabase,
+  studentList: Student[]
+) => {
+  const statement = await database.prepareAsync(
+    'INSERT OR REPLACE INTO student (id, student_number, family_name, given_name, phone_number, email) VALUES (?, ?, ?, ?, ?, ?)'
+  );
+  try {
+    for (const student of studentList) {
+      await statement.executeAsync([
+        student.id,
+        student.student_number,
+        student.family_name,
+        student.given_name,
+        student.phone_number,
+        student.email,
+      ]);
+    }
+  } finally {
+    await statement.finalizeAsync();
+  }
+};
+
 export const fetchReadButNotSentMessages = async (
   database: SQLiteDatabase,
   studentID: string


### PR DESCRIPTION
## Summary
- add demo account detection and local seeding
- avoid network requests in demo mode and show banner
- support storing demo students in SQLite

## Testing
- `npm test -- --watchAll=false` (fails: Cannot read properties of undefined (reading 'ReactCurrentOwner'))
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b4525ebd988327a62c8ab985bb9e59